### PR TITLE
9 configure periphery in initialize method

### DIFF
--- a/assembly/Constants.ts
+++ b/assembly/Constants.ts
@@ -1,10 +1,5 @@
-import { Base58 } from "@koinos/sdk-as";
-
 export namespace Constants {
   export const name: string = "KOINDX LIQUIDITY POOL";
   export const symbol: string = "KOINDX-LP";
   export const decimals: u32 = 8;
-
-  // address
-  export const periphery: Uint8Array = Base58.decode('14WeQjBk7F4C58xUquRGLK1KiqRjwj5Y4J')
 }

--- a/assembly/proto/core.proto
+++ b/assembly/proto/core.proto
@@ -25,12 +25,14 @@ message info {
   uint32 decimals = 3;
 }
 message config_object {  
-  bytes token_a = 1 [(koinos.btype) = ADDRESS];
-  bytes token_b = 2 [(koinos.btype) = ADDRESS];
-  string k_last = 3;
-  uint64 reserve_a = 4 [jstype = JS_STRING];
-  uint64 reserve_b = 5 [jstype = JS_STRING];
-  uint64 block_time = 6 [jstype = JS_STRING];
+  bool initialized = 1;
+  bytes periphery = 2 [(koinos.btype) = ADDRESS];
+  bytes token_a = 3 [(koinos.btype) = ADDRESS];
+  bytes token_b = 4 [(koinos.btype) = ADDRESS];
+  string k_last = 5;
+  uint64 reserve_a = 6 [jstype = JS_STRING];
+  uint64 reserve_b = 7 [jstype = JS_STRING];
+  uint64 block_time = 8 [jstype = JS_STRING];
 }
 
 


### PR DESCRIPTION
Moved the periphery constant to configs so that it is set when the contract is initialized